### PR TITLE
Update README to remove outdated tutorial section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,6 @@ Please refer to our [readthedocs](https://cytopus.readthedocs.io) for more detai
 Learn how to explore the Knowledge Base and retrieve a dicitionary which can be used for [Spectra](https://github.com/dpeerlab/spectra):
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/wallet-maker/cytopus/blob/main/notebooks/KnowledgeBase_queries_colaboratory.ipynb)
 
-### Interactive tutorial for Generating a cytopus Knowledge Base object:
-Learn how to create a Knowledge Base object from gene sets annotations and cell type hierarchies stored in .csv files:
-[here](https://github.com/wallet-maker/cytopus/blob/main/notebooks/KnowledgeBase_construct.ipynb)
-
 ### Interactive utils tutorial - Labeling Factor Analysis Outputs (Spectra):
 Learn how to label marker genes from factor analysis, determine factor cell type specificity and export the Knowledge Base content as .gmt files for other applications:
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/wallet-maker/cytopus/blob/main/notebooks/Cytopus_utils_tutorial.ipynb)


### PR DESCRIPTION
Removed section on generating a cytopus Knowledge Base object.